### PR TITLE
Adds workflow for updating major releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,19 @@
+name: Update Major Release Tag
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  update-tag:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Get major version num and update tag
+        run: |
+          VERSION=${GITHUB_REF#refs/tags/}
+          MAJOR=${VERSION%%.*}
+          git config --global user.name "GitHub Actions"
+          echo "Updating ${MAJOR} tag"
+          git tag -fa ${MAJOR} -m "Update major version tag"
+          git push origin ${MAJOR} --force


### PR DESCRIPTION
Add workflow to update the major version tag (v1, etc) when a new minor version is released. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.