### PR TITLE
Documentation now points to the v2 version

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ To use the action, add a step to your workflow that uses the following syntax.
 
 ```
 - name: Step name
-  uses: aws-actions/aws-secretsmanager-get-secrets@v1
+  uses: aws-actions/aws-secretsmanager-get-secrets@v2
   with:
     secret-ids: |
       secretId1
@@ -90,7 +90,7 @@ The following example creates environment variables for secrets identified by na
 
 ```
 - name: Get secrets by name and by ARN
-  uses: aws-actions/aws-secretsmanager-get-secrets@v1
+  uses: aws-actions/aws-secretsmanager-get-secrets@v2
   with:
     secret-ids: |
       exampleSecretName
@@ -118,7 +118,7 @@ The following example creates environment variables for all secrets with names t
 
 ```
 - name: Get Secret Names by Prefix
-  uses: aws-actions/aws-secretsmanager-get-secrets@v1
+  uses: aws-actions/aws-secretsmanager-get-secrets@v2
   with:
     secret-ids: |
       beta*    # Retrieves all secrets that start with 'beta'
@@ -136,7 +136,7 @@ The following example creates environment variables by parsing the JSON in the s
 
 ```
 - name: Get Secrets by Name and by ARN
-  uses: aws-actions/aws-secretsmanager-get-secrets@v1
+  uses: aws-actions/aws-secretsmanager-get-secrets@v2
   with:
     secret-ids: |
       test/secret


### PR DESCRIPTION
The github actions should run with the Node 20 ([GitHub Actions: Transitioning from Node 16 to Node 20](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/)). We are keeping original `@v1` with the Node 16 to support customers that are running old base images (https://github.com/aws-actions/aws-secretsmanager-get-secrets/issues/73). The `@v2` is based on Node 20 and contains the most recent updates. Updating docs to point to the most recent version.
