### PR TITLE
Package step with email

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -21,8 +21,8 @@ jobs:
           npm run build
       - name: Commit
         run: |
-          git config --global user.name "GitHub Actions"
-          git config --global user.email "bot@github.com"
+          git config user.name "$(git log -n 1 --pretty=format:%an)"
+          git config user.email "$(git log -n 1 --pretty=format:%ae)"
           git add dist/
           git commit -m "chore: Update dist" || echo "No changes to commit"
           git push origin HEAD:main

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -22,6 +22,7 @@ jobs:
       - name: Commit
         run: |
           git config --global user.name "GitHub Actions"
+          git config --global user.email "bot@github.com"
           git add dist/
           git commit -m "chore: Update dist" || echo "No changes to commit"
           git push origin HEAD:main


### PR DESCRIPTION
Every time we merge pull request, the packaging step runs and regenerates the [dist](https://github.com/aws-actions/aws-secretsmanager-get-secrets/commits/main/dist) folder. This step is important, otherwise we're bundling just old code under new tags. As of writing this PR, the latest change is 3 months old in the `dist` folder, but the commit history says that the last change on the repo was made [25 days ago](https://github.com/aws-actions/aws-secretsmanager-get-secrets/commits/main/). 

When I drill to the `package` step ([example](https://github.com/aws-actions/aws-secretsmanager-get-secrets/actions/runs/9036808082/job/24834486471)). Some iterations silently fail on:

```
Run git config --global user.name "GitHub Actions"
Author identity unknown

*** Please tell me who you are.

Run

  git config --global user.email "you@example.com"
  git config --global user.name "Your Name"

to set your account's default identity.
Omit --global to set the identity only in this repository.

fatal: unable to auto-detect email address (got 'runner@fv-az566-[9](https://github.com/aws-actions/aws-secretsmanager-get-secrets/actions/runs/9036808082/job/24834486471#step:4:10)5.(none)')
No changes to commit
Everything up-to-date
```

This seems to be intermittent. I am simply adding `user.email` option. I've tested this on my forked repo, and it seemed to [succeed](https://github.com/jirkafajfr/aws-secretsmanager-get-secrets/actions/runs/9374443808/job/25810474261).