### PR TITLE
Release step with GIT email property

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,8 @@ jobs:
         run: |
           VERSION=${GITHUB_REF#refs/tags/}
           MAJOR=${VERSION%%.*}
-          git config --global user.name "GitHub Actions"
+          git config user.name "$(git log -n 1 --pretty=format:%an)"
+          git config user.email "$(git log -n 1 --pretty=format:%ae)"
           echo "Updating ${MAJOR} tag"
           git tag -fa ${MAJOR} -m "Update major version tag"
           git push origin ${MAJOR} --force


### PR DESCRIPTION
The `release` github action fails on 

```
Updating v2 tag
Committer identity unknown

*** Please tell me who you are.

Run

  git config --global user.email "you@example.com"
  git config --global user.name "Your Name"

to set your account's default identity.
Omit --global to set the identity only in this repository.

fatal: unable to auto-detect email address (got 'runner@fv-az[11](https://github.com/aws-actions/aws-secretsmanager-get-secrets/actions/runs/9451550076/job/26032843476#step:3:12)18-73.(none)')
Error: Process completed with exit code [12](https://github.com/aws-actions/aws-secretsmanager-get-secrets/actions/runs/9451550076/job/26032843476#step:3:13)8.
```
([example](https://github.com/aws-actions/aws-secretsmanager-get-secrets/actions/runs/9451550076/job/26032843476))

That is same problem as in case of https://github.com/aws-actions/aws-secretsmanager-get-secrets/pull/138. Using the same approach to resolve.
