### PR TITLE
Increasing auto select family attempt timeout

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -1,5 +1,10 @@
 name: Builds
 description: Builds the repository and assumes the AWS IAM role for testing
+inputs:
+  aws-region: 
+    description: Region where the credentials will be assumed
+    required: false
+    default: us-east-1
 runs:
   using: composite
   steps:
@@ -24,4 +29,4 @@ runs:
       uses: aws-actions/configure-aws-credentials@v4
       with:
         role-to-assume: ${{ steps.role-to-assume.outputs.arn }}
-        aws-region: us-east-1
+        aws-region: ${{ inputs.aws-region }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -132,3 +132,20 @@ jobs:
           secret-ids: JsonSecret
       - name: Assert Default Is No Json Secrets
         run: npm run integration-test __integration_tests__/parse_json_secrets.test.ts
+
+  af-south-1-integration-test:
+    runs-on: ubuntu-latest
+    needs: unit-tests
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Build
+        uses: ./.github/actions/build
+        with:
+          aws-region: af-south-1
+      - name: Act
+        uses: ./
+        with:
+          secret-ids: JsonSecret
+      - name: Assert
+        run: npm run integration-test __integration_tests__/parse_json_secrets.test.ts


### PR DESCRIPTION
Increasing `AutoSelectFamilyAttemptTimeout` in order to prevent timeouts for the dual-stack endpoints that sits far away from the github runner. There is a few customer reports in https://github.com/aws-actions/aws-secretsmanager-get-secrets/issues/170 describing this. I've added `af-south-1` region to the integration tests and [simulated the same behavior](https://github.com/jirkafajfr/aws-secretsmanager-get-secrets/actions/runs/11245253133/job/31264992394) (roughly 50% executions fails this way). The same behaviour doesn't seem to happen when the timeout is increased (the same advice is given in the https://github.com/nodejs/node/issues/54359).

thank you @georgeboc