### PR TITLE
increase timeout from 1 to 3 seconds.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,7 @@ export async function run(): Promise<void> {
         // A and AAAA records. This behaviour was described in the https://github.com/nodejs/node/issues/54359
         // The default value is 250ms, increasing to 1s. The integration tests stops beeing flaky with this
         // value.
-        setDefaultAutoSelectFamilyAttemptTimeout(1000);
+        setDefaultAutoSelectFamilyAttemptTimeout(3000);
 
         // Default client region is set by configure-aws-credentials
         const client : SecretsManagerClient = new SecretsManagerClient({region: process.env.AWS_DEFAULT_REGION, customUserAgent: "github-action"});


### PR DESCRIPTION
… different region

1 second timeout is not working for us as we have secrets stored in a different region. When we access the secrets located in paris region from sydney region , if fails many times. We make many calls , around 180 and 4-5 will always fail and then we will have to process them separately.

*Issue #, if available:*

4-5 times out of 180 calls with timeout with 1 second timeout set in the code.

*Description of changes:*

Update the timeout to 3 seconds form 1 second.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.