### PR TITLE
Extend cleanup list if list already contains items

### DIFF
--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -263,12 +263,22 @@ describe('Test main action', () => {
         // Set existing cleanup list
         process.env = {...process.env, SECRETS_LIST_CLEAN_UP: JSON.stringify(["EXISTING_TEST_SECRET", "EXISTING_TEST_SECRET_DB_HOST"])};
 
+        const getInputSpy = jest.spyOn(core, 'getInput');
+        getInputSpy.mockImplementation((name) => {
+            switch(name) {
+                case 'auto-select-family-attempt-timeout':
+                    return DEFAULT_TIMEOUT;
+                case 'name-transformation':
+                    return 'uppercase';
+                default:
+                    return '';
+            }
+        });
+
         const booleanSpy = jest.spyOn(core, "getBooleanInput").mockReturnValue(true);
         const multilineInputSpy = jest.spyOn(core, "getMultilineInput").mockReturnValue(
             [TEST_NAME, TEST_INPUT_3, TEST_ARN_INPUT, BLANK_ALIAS_INPUT]
         );
-        const nameTransformationSpy = jest.spyOn(core, 'getInput').mockReturnValue('uppercase');
-
 
 
         // Mock all Secrets Manager calls
@@ -333,7 +343,7 @@ describe('Test main action', () => {
 
         booleanSpy.mockClear();
         multilineInputSpy.mockClear();
-        nameTransformationSpy.mockClear();
+        getInputSpy.mockClear();
     })
     
     test('handles invalid timeout string', async () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -66,6 +66,12 @@ export async function run(): Promise<void> {
             } 
         }
 
+        // Get existing clean up list
+        const existingCleanupSecrets = process.env[CLEANUP_NAME];
+        if (existingCleanupSecrets) {
+            secretsToCleanup = [...JSON.parse(existingCleanupSecrets), ...secretsToCleanup];
+        }
+
         // Export the names of variables to clean up after completion
         core.exportVariable(CLEANUP_NAME, JSON.stringify(secretsToCleanup));
 


### PR DESCRIPTION
*Description of changes:*
When loading secrets in two steps (since some secrets need to be parsed with JSON parsing enabled while others do not), the list of secrets to clean up is incorrect. To fix this, we should extend the original list if it is available.  

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.