### PR TITLE
Fix edge case having a value with numeric start and also a prefix

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -7,6 +7,10 @@ inputs:
     default: us-east-1
 runs:
   using: composite
+  permissions:
+    contents: 'read'
+    id-token: 'write'
+
   steps:
     - name: Install dependencies
       run: npm ci

--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -369,6 +369,16 @@ describe('Test secret parsing and handling', () => {
         expect(transformToValidEnvName('0Admin')).toBe('_0ADMIN')
     });
 
+    test('Maintains single underscore between prefix and numeric properties', () => {
+        const transformedPrefix = transformToValidEnvName('DB', undefined, false);
+        const transformedProperty = transformToValidEnvName('1Password', undefined, true);
+        const result = `${transformedPrefix}_${transformedProperty}`;
+
+        expect(result).toBe('DB_1PASSWORD');
+        expect(result).not.toBe('DB__1PASSWORD');
+        expect(result.includes('__')).toBeFalsy();
+    });
+
     test('Transformation function is applied', () => {
         expect(transformToValidEnvName('secret3', (x) => x.toUpperCase())).toBe('SECRET3')
     });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -149,8 +149,8 @@ export function injectSecret(
 
             // Append the current key to the name of the env variable and check to avoid prepending an underscore
             const newEnvName = [
-                tempEnvName || transformToValidEnvName(secretName, nameTransformation),
-                transformToValidEnvName(k, nameTransformation)
+                tempEnvName || transformToValidEnvName(secretName, nameTransformation, false),
+                transformToValidEnvName(k, nameTransformation, !!tempEnvName)
             ]
             .filter(elem => elem) // Uses truthy-ness of elem to determine if it remains
             .join("_"); // Join the remaining elements with an underscore
@@ -195,9 +195,9 @@ export function isJSONString(secretValue: string): boolean {
  * Transforms the secret name into a valid environmental variable name
  * It should consist of only upper case letters, digits, and underscores and cannot begin with a number
  */
-export function transformToValidEnvName(secretName: string, nameTransformation?: TransformationFunc): string {
+export function transformToValidEnvName(secretName: string, nameTransformation?: TransformationFunc, hasPrefix : boolean = false): string {
     // Leading digits are invalid
-    if (secretName.match(/^[0-9]/)){
+    if (!hasPrefix && secretName.match(/^[0-9]/) && !secretName.startsWith('_')) {
         secretName = '_'.concat(secretName);
     }
 


### PR DESCRIPTION
*Issue #, if available:*
Fixes #238 

*Description of changes:*
Added an extra flag check to not include an extra underscore for the value starting with number if it already has a prefix.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.