### PR TITLE
ci: scope down GitHub token permissions for release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,10 @@ on:
   release:
     types: [created]
 
+
+permissions:
+  contents: write
+
 jobs:
   update-tag:
     runs-on: ubuntu-latest


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Scope down GitHub token permissions for release.yml

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.